### PR TITLE
Update doctests to match Python ≥3.10 IPv6 formatting

### DIFF
--- a/diamond_miner/format.py
+++ b/diamond_miner/format.py
@@ -9,7 +9,7 @@ def format_probe(
     Examples:
         >>> from diamond_miner.format import format_probe
         >>> format_probe(281470816487432, 24000, 33434, 1, "icmp")
-        '::ffff:808:808,24000,33434,1,icmp'
+        '::ffff:8.8.8.8,24000,33434,1,icmp'
     """
     return f"{format_ipv6(dst_addr_v6)},{src_port},{dst_port},{ttl},{protocol}"
 
@@ -19,6 +19,6 @@ def format_ipv6(addr: int) -> str:
     Convert an IPv6 UInt128 to a string.
         >>> from diamond_miner.format import format_ipv6
         >>> format_ipv6(281470816487432)
-        '::ffff:808:808'
+        '::ffff:8.8.8.8'
     """
     return str(IPv6Address(addr))

--- a/diamond_miner/generators/database.py
+++ b/diamond_miner/generators/database.py
@@ -44,7 +44,7 @@ def probe_generator_from_database(
         >>> len(probes)
         8
         >>> (str(ip_address(probes[0][0])), *probes[0][1:])
-        ('::ffff:808:100', 24000, 33434, 1, 'icmp')
+        ('::ffff:8.8.1.0', 24000, 33434, 1, 'icmp')
     """
     global max_probes
     if max_probes == 0:

--- a/diamond_miner/subsets.py
+++ b/diamond_miner/subsets.py
@@ -28,11 +28,11 @@ def subsets_for(
         >>> from diamond_miner.test import client
         >>> from diamond_miner.queries import GetLinks, GetProbes, GetResults
         >>> subsets_for(GetLinks(), client, 'test_nsdi_example', max_items_per_subset=1)
-        [IPv6Network('::ffff:c800:0/112')]
+        [IPv6Network('::ffff:200.0.0.0/112')]
         >>> subsets_for(GetProbes(round_eq=1), client, 'test_nsdi_example', max_items_per_subset=1)
-        [IPv6Network('::ffff:c800:0/112')]
+        [IPv6Network('::ffff:200.0.0.0/112')]
         >>> subsets_for(GetResults(), client, 'test_nsdi_example', max_items_per_subset=1)
-        [IPv6Network('::ffff:c800:0/112')]
+        [IPv6Network('::ffff:200.0.0.0/112')]
     """
     if isinstance(query, LinksQuery):
         count_query = CountLinksPerPrefix(**common_parameters(query, LinksQuery))
@@ -65,9 +65,9 @@ def split(counts: Counts, max_items_per_subset: int) -> list[IPv6Network]:
         >>> split(counts, 15)
         [IPv6Network('::/0')]
         >>> split(counts, 10)
-        [IPv6Network('::ffff:808:0/117'), IPv6Network('::ffff:808:800/117')]
+        [IPv6Network('::ffff:8.8.0.0/117'), IPv6Network('::ffff:8.8.8.0/117')]
         >>> split(counts, 1) # Impossible case, should return the minimal feasible networks.
-        [IPv6Network('::ffff:808:400/120'), IPv6Network('::ffff:808:800/120')]
+        [IPv6Network('::ffff:8.8.4.0/120'), IPv6Network('::ffff:8.8.8.0/120')]
         >>> split({}, 10)
         []
     """
@@ -95,7 +95,7 @@ def addr_to_network(addr: str, prefix_len_v4: int, prefix_len_v6: int) -> IPv6Ne
     """
     Examples:
         >>> addr_to_network("::ffff:8.8.8.0", 24, 64)
-        IPv6Network('::ffff:808:800/120')
+        IPv6Network('::ffff:8.8.8.0/120')
         >>> addr_to_network("2001:4860:4860:1234::", 24, 64)
         IPv6Network('2001:4860:4860:1234::/64')
     """

--- a/tests/test_generator_standalone.py
+++ b/tests/test_generator_standalone.py
@@ -57,7 +57,7 @@ def test_probe_generator_32():
     probes = [x for x in generator]
     assert len(probes) == len(set(probes)) == 6
     for addr, src_port, dst_port, ttl, protocol in probes:
-        assert str(ip_address(addr)) == "::ffff:808:808"
+        assert str(ip_address(addr)) == "::ffff:8.8.8.8"
         assert src_port in range(24010, 24013)
         assert dst_port == 33434
         assert ttl in range(41, 43)
@@ -76,10 +76,7 @@ def test_probe_generator_23():
     probes = [x for x in generator]
     assert len(probes) == len(set(probes)) == 2
     for addr, src_port, dst_port, ttl, protocol in probes:
-        assert str(ip_address(addr)) in [
-            "::ffff:0:a",
-            "::ffff:0:10a",
-        ]
+        assert str(ip_address(addr)) in ["::ffff:0.0.0.10", "::ffff:0.0.1.10"]
         assert src_port == 24000
         assert dst_port == 33434
         assert ttl == 41
@@ -104,10 +101,10 @@ def test_probe_generator_by_flow():
     assert len(probes) == len(set(probes)) == 16
     for addr, src_port, dst_port, ttl, protocol in probes:
         assert str(ip_address(addr)) in [
-            "::ffff:0:a",
-            "::ffff:0:b",
-            "::ffff:0:10a",
-            "::ffff:0:10b",
+            "::ffff:0.0.0.10",
+            "::ffff:0.0.0.11",
+            "::ffff:0.0.1.10",
+            "::ffff:0.0.1.11",
             "2001:4860:4860::8888",
         ]
         assert src_port in [24000, 24010, 24011]


### PR DESCRIPTION
Python 3.10+ changed the canonical string representation of IPv4-mapped IPv6 addresses (e.g. '::ffff:808:808' → '::ffff:8.8.8.8'). This commit updates doctest and test expectations accordingly. 
No functional changes to code or packet output.